### PR TITLE
Add support for initializing from strings that are frozen 

### DIFF
--- a/lib/chroma/rgb_generator.rb
+++ b/lib/chroma/rgb_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Chroma
   # Main module to generate an instance of {ColorModes::Rgb} from several
   # possible inputs.

--- a/lib/chroma/rgb_generator/from_string.rb
+++ b/lib/chroma/rgb_generator/from_string.rb
@@ -77,10 +77,7 @@ module Chroma
       end
 
       def normalize_input(input)
-        input.clone.tap do |str|
-          str.strip!
-          str.downcase!
-        end
+        input.strip.downcase
       end
 
       def matchers


### PR DESCRIPTION
As the current implementation was mutating the string, the following would raise an error:
```
'red'.freeze.paint
```